### PR TITLE
[prototype] Add initial table of software projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ env
 lib
 venv
 wheels
+
+# Generated files
+
+content/_generated_software_table.md

--- a/content/software_projects.md
+++ b/content/software_projects.md
@@ -1,0 +1,4 @@
+## Software projects
+
+```{literalinclude} _generated_software_table.md
+```

--- a/data/software_projects.toml
+++ b/data/software_projects.toml
@@ -1,7 +1,13 @@
-[[project]]
+[[ project ]]
 name = "PlasmaPy"
 docs = "https://docs.plasmapy.org"
-url = "https://www.plasmapy.org"
+github = "https://github.org/PlasmaPy/PlasmaPy"
 description = "Python package for plasma research and education"
 license = "BSD 3-Clause"
-languages = [ "Python" ]
+
+[[ project ]]
+name = "OMAS"
+docs = "https://gafusion.github.io/omas"
+github = "https://github.com/gafusion/omas"
+description = "Library to interface with the ITER Integrated Modeling and Analysis Suite"
+license = "MIT"

--- a/data/software_projects.toml
+++ b/data/software_projects.toml
@@ -1,0 +1,7 @@
+[[project]]
+name = "PlasmaPy"
+docs = "https://docs.plasmapy.org"
+url = "https://www.plasmapy.org"
+description = "Python package for plasma research and education"
+license = "BSD 3-Clause"
+languages = [ "Python" ]

--- a/myst.yml
+++ b/myst.yml
@@ -15,6 +15,7 @@ project:
 
   toc:
   - file: content/index.md
+  - file: content/software_projects.md
 
   keywords:
   - open science

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,16 +1,40 @@
 # /// script
-# dependencies = ["nox", "uv"]
+# dependencies = ["nox", "uv", "py-markdown-table"]
 # ///
 
 import nox
+from py_markdown_table.markdown_table import markdown_table
+import tomllib
+import pathlib
 
 nox.options.sessions = ["lint"]
 nox.options.default_venv_backend = "uv|virtualenv"
 
 
 @nox.session
-def build(session):
-    session.install("uv")
+def build(session: nox.Session) -> None:
+    """Build the website."""
+    session.notify("software_table")
+    session.notify("mystify")
+
+
+@nox.session
+def software_table(session: nox.Session) -> None:
+
+    software_projects_path = pathlib.Path("data/software_projects.toml")
+    with software_projects_path.open("rb") as data_file:
+        software_projects = tomllib.load(data_file)
+
+    projects_table = markdown_table(software_projects["project"]).get_markdown()
+
+    generated_file = pathlib.Path("content/_generated_software_table.md")
+
+    with generated_file.open("w") as out_file:
+        out_file.write(projects_table)
+
+@nox.session
+def mystify(session: nox.Session) -> None:
+    """Run mystmd."""
     session.run("uvx", "--from=mystmd", "myst", "build", "--all", "--html")
 
 


### PR DESCRIPTION
This PR creates a [Nox](https://nox.thea.codes) session to generate a Markdown file containing a table of software projects. This file is then included in a Markdown page for software projects.  This was inspired by the [PyHC projects page](https://heliopython.org/projects/) created by @sapols.  

 - I tentatively chose [TOML](https://toml.io/en/) as the format for the software projects data file, but I'd be content to go with [YAML](https://yaml.org) instead.  
 - This PR initially uses [`py-markdown-table`](https://pypi.org/project/py-markdown-table/), which is a pretty light dependency.  Another possibility would be [`pytablewriter`](https://github.com/thombashi/pytablewriter), which has more extensive functionality.

 - We'll likely want to do some processing of the contents being read in from the TOML file. For example, the PyHC projects page uses the GitHub or GitLab icon for the repository, a books icon for the documentation, and a 🌐 icon for the page on the World Wide Web.

 - I put functionality directly in `noxfile.py` for the prototype, but I suspect we'll want to refactor it into a separate Python script.

